### PR TITLE
Adds entry for Password Validator for PHP

### DIFF
--- a/source/_posts/php-password-validator.md
+++ b/source/_posts/php-password-validator.md
@@ -2,7 +2,7 @@
 title: "Password Validator for PHP"
 layout: "post"
 color: "fff"
-background: "59a93a"
+background: "F26522"
 author: "Jeremy Kendall"
 author_url: "http://about.me/jeremykendall"
 author_twitter: JeremyKendall


### PR DESCRIPTION
The tile for this article is pooched. Not sure how to fix that.
"Password Validator for PHP" displays only "Password" on the tile, and
"PV PHP" isn't the name of the lib, but fits on the tile. Not sure how
you want to handle that.
