### PR TITLE
fix composer require for password-compat

### DIFF
--- a/source/_posts/silex.md
+++ b/source/_posts/silex.md
@@ -21,7 +21,7 @@ the [password_compat] [2] library in your projects to enable `bcrypt` in PHP
 5.3.17+ versions:
 
 ```sh
-$ composer require ircmaxell/password_compat
+$ composer require ircmaxell/password-compat
 ```
 
 ## Usage


### PR DESCRIPTION
I missed one in the Silex documentation.