### PR TITLE
Update link to Google font so it loads over HTTPS to avoid mixed content errors

### DIFF
--- a/source/themes/dshafik/securepasswords.info/_layouts/index.twig.html
+++ b/source/themes/dshafik/securepasswords.info/_layouts/index.twig.html
@@ -9,7 +9,7 @@
     <link href="/components/bootstrap/css/bootstrap.min.css" rel="stylesheet">
     <link href="/components/font-awesome/css/font-awesome.min.css" rel="stylesheet">
     <link href="/{{ theme_path('assets/css/site.css') }}" rel="stylesheet">
-	<link href='http://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>     
+    <link href='https://fonts.googleapis.com/css?family=Lobster' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="{{ site.url }}/components/highlightjs/styles/github.css" />
     <link rel="shortcut icon" href="/{{ theme_path('assets/images/ico/favicon.ico') }}">
 </head><!--/head-->


### PR DESCRIPTION
Currently Google Chrome (and possibly other browsers too) gives an error about a font that wants loading over HTTP while the website is loaded over HTTPS, causing the font not to be loaded at all (mixed content error).

By loading the font over HTTP always we avoid this problem. We could have loaded the font using the schema-less protocol (//), but that's known to cause problems, so always loading over HTTPS is our best option here.